### PR TITLE
Add some resiliency by looping and retrying

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ A Clojure library for safely and reliably consuming SQS messages.
   ;; ... do something fancy
   )
 
-(let [client (sqs/client "AKIA..."
-                         "8jcNZ9mM..."
-                         #aws/region "US_EAST_1")]
-  (sqs/consume-messages client
+(let [creds {:access-key "AKIA..."
+             :access-secret "8jcNZ9mM..."
+             :region #aws/region "US_EAST_1"}]
+  (sqs/consume-messages creds
                         "incomming-queue"
                         "failure-queue"
                         process-message))

--- a/src/squishy/core.clj
+++ b/src/squishy/core.clj
@@ -15,19 +15,28 @@
 (defn safe-process [client fail-queue-url f]
   (fn [message]
     (log/debug "Processing SQS message:" (str "<<" message ">>"))
-    (try (f message)
-      (catch Exception e
+    (try
+      (f message)
+      (catch Throwable e
         (let [body (:body message)]
           (log/error "Failed to process" body e)
           (report-error client fail-queue-url body e))))))
 
 (defn consume-messages
-  [client queue-name fail-queue-name f]
-  (let [queue-url (sqs/create-queue client queue-name)
-        fail-queue-url (sqs/create-queue client fail-queue-name)]
-    (future
-      (do
-        (log/info "Consuming SQS messages from" queue-url)
-        (dorun
-         (map (sqs/deleting-consumer client (safe-process client fail-queue-url f))
-              (sqs/polling-receive client queue-url :max-wait Long/MAX_VALUE :limit 10)))))))
+  [creds queue-name fail-queue-name f]
+  (future
+    (loop []
+      (let [client (client (:access-key creds)
+                           (:access-secret creds)
+                           (:region creds))
+            queue-url (sqs/create-queue client queue-name)
+            fail-queue-url (sqs/create-queue client fail-queue-name)
+            consume (sqs/deleting-consumer client (safe-process client fail-queue-url f))]
+        (when (try
+                (log/info "Consuming SQS messages from" queue-url)
+                (doseq [message (sqs/polling-receive client queue-url :max-wait Long/MAX_VALUE :limit 10)]
+                  (consume message))
+                (catch Throwable t
+                  (log/error "Failed to consume-messages" t)
+                  :keep-trying))
+          (recur))))))

--- a/src/squishy/core.clj
+++ b/src/squishy/core.clj
@@ -22,21 +22,34 @@
           (log/error "Failed to process" body e)
           (report-error client fail-queue-url body e))))))
 
+(def backoff-start 1000)
+(def max-failures  10)
+
 (defn consume-messages
   [creds queue-name fail-queue-name f]
   (future
-    (loop []
-      (let [client (client (:access-key creds)
-                           (:access-secret creds)
-                           (:region creds))
-            queue-url (sqs/create-queue client queue-name)
-            fail-queue-url (sqs/create-queue client fail-queue-name)
-            consume (sqs/deleting-consumer client (safe-process client fail-queue-url f))]
+    (let [rec (atom {:failures 0
+                     :backoff  backoff-start})]
+      (loop []
         (when (try
-                (log/info "Consuming SQS messages from" queue-url)
-                (doseq [message (sqs/polling-receive client queue-url :max-wait Long/MAX_VALUE :limit 10)]
-                  (consume message))
+                (let [client (client (:access-key creds)
+                                     (:access-secret creds)
+                                     (:region creds))
+                      queue-url (sqs/create-queue client queue-name)
+                      fail-queue-url (sqs/create-queue client fail-queue-name)
+                      consume (sqs/deleting-consumer client (safe-process client fail-queue-url f))]
+                  (log/info "Consuming SQS messages from" queue-url)
+                  (doseq [message (sqs/polling-receive client queue-url :max-wait Long/MAX_VALUE :limit 10)]
+                    (reset! rec {:failures 0 :backoff backoff-start})
+                    (consume message)))
                 (catch Throwable t
                   (log/error "Failed to consume-messages" t)
+                  (swap! rec update :failures inc)
                   :keep-trying))
-          (recur))))))
+          (let [{:keys [failures backoff]} @rec]
+            (if (>= failures max-failures)
+              (log/fatal "Failed" failures "times, exiting.")
+              (do
+                (Thread/sleep backoff)
+                (swap! rec update :backoff (partial * 2))
+                (recur)))))))))

--- a/test/squishy/core_test.clj
+++ b/test/squishy/core_test.clj
@@ -6,36 +6,61 @@
 (deftest consume-messages-test
   (testing "calls function arg on each msg"
     (let [result (atom [])]
-      (with-redefs [sqs/create-queue (constantly nil)
+      (with-redefs [client (constantly nil)
+                    sqs/create-queue (constantly nil)
                     sqs/delete (constantly nil)
                     sqs/polling-receive (constantly ["msg 1" "msg 2"])]
+        @(consume-messages nil nil nil
+                           #(swap! result conj
+                                   (clojure.string/upper-case %)))
         (is (= ["MSG 1" "MSG 2"]
-               (do
-                 @(consume-messages nil nil nil
-                                    #(swap! result conj
-                                            (clojure.string/upper-case %)))
-                 @result))))))
+               @result)))))
 
   (testing "deletes msgs as it consumes them"
     (let [queue (atom ["msg 1" "msg 2"])]
-      (with-redefs [sqs/create-queue (constantly nil)
+      (with-redefs [client (constantly nil)
+                    sqs/create-queue (constantly nil)
                     sqs/polling-receive (constantly @queue)
                     sqs/delete (fn [client message]
                                  (swap! queue #(drop 1 %)))]
+        @(consume-messages nil nil nil (constantly nil))
         (is (= []
-               (do
-                 @(consume-messages nil nil nil (constantly nil))
-                 @queue))))))
+               @queue)))))
 
   (testing "puts msgs on fail queue when processing fn throws exception"
     (let [fail-queue (atom [])]
-      (with-redefs [sqs/create-queue (constantly nil)
+      (with-redefs [client (constantly nil)
+                    sqs/create-queue (constantly nil)
                     sqs/polling-receive (constantly [{:body "msg 1"}
                                                      {:body "msg 2"}])
                     sqs/delete (constantly nil)
                     sqs/send (fn [client q msg] (swap! fail-queue conj msg))]
+        @(consume-messages
+          nil nil nil #(throw (Exception. (str (:body %) " failed"))))
         (is (= ["{:body \"msg 1\", :error \"msg 1 failed\"}"
                 "{:body \"msg 2\", :error \"msg 2 failed\"}"]
-               (do @(consume-messages
-                     nil nil nil #(throw (Exception. (str (:body %) " failed"))))
-                   @fail-queue)))))))
+               @fail-queue)))))
+
+  (testing "can recover from polling-receive errors"
+    (let [queue (atom (list (constantly 1)
+                            (fn [& _] (throw (RuntimeException. "1")))
+                            (constantly 2)
+                            (fn [& _] (throw (RuntimeException. "2")))
+                            (constantly 3)))
+          done (atom [])]
+      (with-redefs [client (constantly nil)
+                    sqs/create-queue (constantly nil)
+                    sqs/polling-receive (fn [& _]
+                                          (letfn [(r []
+                                                    (lazy-seq
+                                                     (when (seq @queue)
+                                                       (let [x (first @queue)]
+                                                         (swap! queue rest)
+                                                         (cons (x) (r))))))]
+                                            (r)))
+                    sqs/delete (constantly nil)
+                    sqs/send (constantly nil)]
+        @(consume-messages
+          nil nil nil #(swap! done conj %))
+        (is (= [1 2 3]
+               @done))))))


### PR DESCRIPTION
SQS can sometimes disconnect or fail on a request. This patch introduces a retry loop inside of `consume-messages`. There's a slight modification. Instead of taking a client, `consume-messages` now takes the information to build a client (`access-key`, `access-secret`, and `region`).