### PR TITLE
Handle more region formats

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## Changes between 3.0.1 and 3.1.0
+
+### Improved Region configuration support
+
+Whereas before the only acceptable string format for the `#aws/region` tag
+was the region enum format (i.e. "US_WEST_1"), the tag can now also take the
+more common name format (i.e. "us-west-1"). The `start-consumer` now can take
+either of the string formats or a `com.amazonaws.regions.Region` instance, whereas
+before it only took the instance type.
+
+See the Region section of the README.
+
 ## Changes between 3.0.0 and 3.0.1
 
 ### Excluded `logback.xml` from library JAR file

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ A Clojure library for safely and reliably consuming SQS messages.
 (sqs/stop-consumer @consumer-id)
 ```
 
+### Region
+
+You can send several values in for the `:region` component of the credentials.
+
+* "us-east-1": you can send in a string that conforms to the "name" of the region, lowercase with dashes
+* "US_EAST_1": you can send in a string that conforms to the string version of the Regions enum, uppercase with underscores
+* com.amazonaws.regions.Region: you can send in an actual instance of the Region class
+
+There's a data-reader tag defined as `#aws/region` that can convert a string in either of
+the top two formats into a Region class instance as well.
+
 ### Shutting down
 
 **IMPORTANT:** Squishy is quite aggressive at recovering from exceptions and

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,9 @@
   :url "https://github.com/democracyworks/squishy"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [com.amazonaws/aws-java-sdk-sqs "1.11.407"]
-                 [org.clojure/tools.logging "0.4.1"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [com.amazonaws/aws-java-sdk-sqs "1.11.582"]
+                 [org.clojure/tools.logging "0.5.0-alpha.1"]
                  [ch.qos.logback/logback-classic "1.2.3"]
                  [com.cemerick/bandalore "0.0.6"
                   :exclusions [com.amazonaws/aws-java-sdk]]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject democracyworks/squishy "3.0.3-SNAPSHOT"
+(defproject democracyworks/squishy "3.1.0-SNAPSHOT"
   :description "A library for consuming Amazon SQS queue messages"
   :url "https://github.com/democracyworks/squishy"
   :license {:name "Eclipse Public License"

--- a/src/squishy/data_readers.clj
+++ b/src/squishy/data_readers.clj
@@ -1,7 +1,16 @@
 (ns squishy.data-readers
+  (:require [clojure.string :as str])
   (:import [com.amazonaws.regions Region Regions]))
 
-(defn aws-region [region-name]
-  (-> region-name
-      (Regions/valueOf)
-      (Region/getRegion)))
+(defn aws-region
+  "Attempts to coerce the string into a Java Region instance. Can accept
+   either of the two string versions of a region name, lowercase with dashes
+   (e.g. `us-east-1`) or uppercase with underscores (e.g. `US_WEST_1`)."
+  [region-name]
+  (if (str/includes? region-name "_")
+    (-> region-name
+        Regions/valueOf
+        Region/getRegion)
+    (-> region-name
+        Regions/fromName
+        Region/getRegion)))


### PR DESCRIPTION
* expand the data-reader tag to take either string
format regions commonly appear as (`US_EAST_1` and
`us-east-1`)
* coerce the `:region` in the `start-consumer` creds
into a Region instance if it's one of the string
formats